### PR TITLE
add restore of WAIC state to saveMCMCstate and restarting MCMC

### DIFF
--- a/restartingMCMC/restartingMCMC.Rmd
+++ b/restartingMCMC/restartingMCMC.Rmd
@@ -84,8 +84,11 @@ We'll leave the
 conjugate sampler that is assigned to `mu`, and the`RW` samplers
 assigned to the `beta` and `epsilon` terms.
 
+You can decide whether or not to include WAIC by setting `useWAIC`.
+
 ```{r }
-conf <- configureMCMC(Rmodel)
+useWAIC <- TRUE
+conf <- configureMCMC(Rmodel, enableWAIC = useWAIC)
 conf$printSamplers()
 conf$removeSamplers("sigma")
 conf$addSampler("sigma", "slice")
@@ -122,6 +125,7 @@ Now, before ending the R session, we'll need to save several things:
 3. The internal state variables from all the MCMC samplers.  This will
 be the slightly tricky part, but not too difficult.
 4. R's random number seed.
+5. If using WAIC, the internal state variables for the WAIC calculation.
 
 \   
 
@@ -290,6 +294,25 @@ continued, had we actually kept running the MCMC chain now.
 seed <- .Random.seed
 ```
 
+##### WAIC State Variables  
+
+If you're using WAIC, you'll also need to save the current values of some WAIC-related quantities that are used in NIMBLE's online WAIC algorithm.
+
+```{r }
+waicState <- list()
+if(useWAIC) {
+    waicState$mcmcIter <- valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "mcmcIter")
+    waicState$lppdSumMaxMat <- valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "lppdSumMaxMat")
+    waicState$lppdCurSumMat <- valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "lppdCurSumMat")
+    waicState$sspWAICmat <- valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "sspWAICmat")
+    waicState$meanpWAICmat <- valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "meanpWAICmat")
+    waicState$delta1pWAICmat <- valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "delta1pWAICmat")
+    waicState$delta2pWAICmat <- valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "delta2pWAICmat")
+    waicState$logProbMat <- valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "logProbMat")
+    waicState$finalized <- valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "finalized")
+}
+```
+
 \   
 
 Now, save all these to a file.
@@ -297,7 +320,7 @@ Now, save all these to a file.
 
 ```{r }
 fileName <- '~/temp/restartMCMC.RData'
-save(samples, modelVariables, samplerStates, seed, file = fileName)
+save(samples, modelVariables, samplerStates, waicState, seed, file = fileName)
 ```
 
 
@@ -348,7 +371,7 @@ Rmodel <- nimbleModel(code, constants, data, inits)
 
 Rmodel$calculate()
 
-conf <- configureMCMC(Rmodel)
+conf <- configureMCMC(Rmodel, enableWAIC = useWAIC)
 conf$removeSamplers("sigma")
 conf$addSampler("sigma", "slice")
 conf$printSamplers()
@@ -451,6 +474,26 @@ off.
 
 \   
 
+##### Restore the sampler state variables 
+
+If using WAIC, restore the WAIC state variables.
+
+```{r}
+if(useWAIC) {
+    valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "mcmcIter", waicState[["mcmcIter"]])
+    valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "lppdSumMaxMat", waicState[["lppdSumMaxMat"]])
+    valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "lppdCurSumMat", waicState[["lppdCurSumMat"]])
+    valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "sspWAICmat", waicState[["sspWAICmat"]])
+    valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "meanpWAICmat", waicState[["meanpWAICmat"]])
+    valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "delta1pWAICmat", waicState[["delta1pWAICmat"]])
+    valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "delta2pWAICmat", waicState[["delta2pWAICmat"]])
+    valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "logProbMat", waicState[["logProbMat"]])
+    valueInCompiledNimbleFunction(Cmcmc$waicFun[[1]], "finalized", waicState[["finalized"]])
+}                                                 
+```
+
+\
+
 ## Continue Running MCMC
 
 You can now continue running the `Cmcmc` algorithm, and it will
@@ -460,9 +503,11 @@ Just make sure to use the
 `reset = FALSE` argument, so it doesn't reset all the samplers back to
 their initial states.
 
+And if using WAIC, similarly set `resetWAIC = FALSE`.
+
 
 ```{r }
-Cmcmc$run(10000, reset = FALSE)
+Cmcmc$run(10000, reset = FALSE, resetWAIC = FALSE)
 samples_continued <- as.matrix(Cmcmc$mvSamples)
 ```
 
@@ -493,6 +538,11 @@ samples_all[9995:10005,]
 ## [11,] 1.331974 0.2388559 2.694611 0.03243129
 ```
 
+If using WAIC, we can look at the WAIC value from the combined runs.
+
+```{r}
+Cmcmc$getWAIC()
+```
 
 \   
 
@@ -539,7 +589,7 @@ Rmodel <- nimbleModel(code, constants, data, inits)
 
 Rmodel$calculate()
 
-conf <- configureMCMC(Rmodel)
+conf <- configureMCMC(Rmodel, enableWAIC = useWAIC)
 conf$removeSamplers("sigma")
 conf$addSampler("sigma", "slice")
 conf$printSamplers()
@@ -554,6 +604,9 @@ Cmcmc$run(20000)
 samples_all <- as.matrix(Cmcmc$mvSamples)
 dim(samples_all)
 samples_all[9995:10005,]
+
+if(useWAIC)
+    Cmcmc$getWAIC()
 ```
 
 \   

--- a/saveMCMCstate/saveMCMCstate.Rmd
+++ b/saveMCMCstate/saveMCMCstate.Rmd
@@ -87,6 +87,22 @@ getMCMCstate <- function(conf, mcmc) {
     return(mcmcStateValuesList)
 }
 
+getWAICstate <- function(mcmc) {
+    waicStateNames <- c('delta1pWAICmat', 'delta2pWAICmat', 'finalized', 'logProbMat', 'lppdCurSumMat', 'lppdSumMaxMat',
+       'mcmcIter', 'meanpWAICmat', 'sspWAICmat')
+    waicStateList <- vector('list', length(waicStateNames))
+    names(waicStateList) <- waicStateNames
+    for(nm in waicStateNames) {
+        if(is.nf(mcmc)) {
+            waicStateList[[nm]] <- mcmc$waicFun[[1]][[nm]]
+        }
+        if(is.Cnf(mcmc)) {
+            waicStateList[[nm]] <- valueInCompiledNimbleFunction(mcmc$waicFun[[1]], nm)
+        }
+    }
+    return(waicStateList)
+}
+
 setModelState <- function(model, modelState) {
     modelVarNames <- model$getVarNames()
     if(!identical(sort(modelVarNames), sort(names(modelState)))) stop('saved model variables don\'t agree')
@@ -121,6 +137,17 @@ setMCMCstate <- function(conf, mcmc, mcmcState) {
         }
     }
 }
+
+setWAICstate <- function(mcmc, waicState) {
+    for(nm in names(waicState)) {
+        if(is.nf(mcmc)) {
+            mcmc$waicFun[[1]][[nm]] <- waicState[[nm]]
+        }                       
+        if(is.Cnf(mcmc)) {
+            invisible(valueInCompiledNimbleFunction(mcmc$waicFun[[1]], nm, waicState[[nm]]))
+        }
+    }
+}
 ```
 
 
@@ -137,6 +164,7 @@ library(nimble)
 \  
  
 Define a NIMBLE model object, and an MCMC algorithm to operate on it.
+Optionally, choose to calculate WAIC.
 
 The saving / loading state will work for *most any* NIMBLE MCMC algorithms, but
 if you have questions about your use case, then
@@ -145,6 +173,8 @@ please email Daniel at `dbt1@williams.edu`.
 \  
 
 ```{r }
+useWAIC <- TRUE
+
 code <- nimbleCode({
     for(i in 1:N) {
         x[i] ~ dnorm(0, 1)
@@ -168,7 +198,7 @@ Rmodel <- nimbleModel(code, constants, data, inits)
 Rmodel$calculate()
 
 ## configure & build MCMC
-conf <- configureMCMC(Rmodel)
+conf <- configureMCMC(Rmodel, enableWAIC = useWAIC)
 conf$removeSamplers(c('b', 'x'))
 conf$addSampler('b', 'binary')
 conf$addSampler('x[1]', 'RW')
@@ -200,6 +230,8 @@ For saving the MCMC state, you'll need both the compiled MCMC object
 ```{r }
 stateList <- list(modelState = getModelState(Cmodel),
                   mcmcState = getMCMCstate(conf, Cmcmc))
+if(useWAIC)
+    stateList[['waicState']] <- getWAICstate(Cmcmc)
 
 saveRDS(stateList, file = '~/temp/state.rds')
 ```
@@ -218,7 +250,7 @@ previous "state" back into them.
 Rmodel2 <- nimbleModel(code, constants, data, inits)
 
 ## construct an *identical* MCMC algorithm
-conf2 <- configureMCMC(Rmodel2)
+conf2 <- configureMCMC(Rmodel2, enableWAIC = useWAIC)
 conf2$removeSamplers(c('b', 'x'))
 conf2$addSampler('b', 'binary')
 conf2$addSampler('x[1]', 'RW')
@@ -246,10 +278,14 @@ stateList <- readRDS(file = '~/temp/state.rds')
 
 modelState <- stateList$modelState
 mcmcState <- stateList$mcmcState
+if(useWAIC)
+    waicState <- stateList$waicState
 
 ## restore the saved "state" into the new model and new MCMC
 setModelState(Cmodel2, modelState)
 setMCMCstate(conf2, Cmcmc2, mcmcState)
+if(useWAIC)
+    setWAICstate(Cmcmc2, waicState)
 ```
 
 \  
@@ -258,7 +294,7 @@ Finally, now you can "resume" the MCMC run, exactly where it left off.
 
 **Important:** Make certain to use the argument `reset = FALSE`, so the
   MCMC state is *not reset* to its initial settings for a new, fresh,
-  MCMC run.
+  MCMC run. If calculating WAIC, also set `resetWAIC = FALSE`.
 
 This option, `reset = FALSE`, is only available through the
 `mcmc$run(...)` invocation of the MCMC algorithm.
@@ -267,7 +303,7 @@ This option, `reset = FALSE`, is only available through the
 
 ```{r }
 ## continue MCMC run
-Cmcmc$run(10000, reset = FALSE)
+Cmcmc2$run(10000, reset = FALSE, resetWAIC = FALSE)
 ```
 
 \   


### PR DESCRIPTION
See what you think (this relates to nimbleCoreTeam issue 349). 

I wasn't able to generate the HTML because you have a hard-coded path `~/temp`. (I'd recommend you just save and load the files from whatever the current working directory is.)

If you want, I can make that path on my machine, but I think it's best to modify the path stuff.

